### PR TITLE
fix(copilot-auto-fix): Copilot レビュー指摘4件を修正

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/scripts/auto-fix/check-forbidden.sh
+++ b/.github/scripts/auto-fix/check-forbidden.sh
@@ -3,7 +3,7 @@
 #
 # 入力（環境変数）:
 #   PR_NUMBER          — 対象PR番号
-#   FORBIDDEN_PATTERNS — 禁止パターン（改行区切りのglob。例: ".env*\npyproject.toml"）
+#   FORBIDDEN_PATTERNS — 禁止パターン（改行区切りのglob。空の場合はスキップ）
 #   GITHUB_OUTPUT      — GitHub Actions 出力ファイル
 #   GH_TOKEN           — GitHub トークン（env経由で gh CLI が自動参照）
 #
@@ -18,7 +18,14 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "$(dirname "$0")/_common.sh"
 
-require_env PR_NUMBER FORBIDDEN_PATTERNS GITHUB_OUTPUT
+require_env PR_NUMBER GITHUB_OUTPUT
+
+# FORBIDDEN_PATTERNS が空の場合は禁止パターンなしとして即終了
+if [ -z "${FORBIDDEN_PATTERNS:-}" ]; then
+  echo "forbidden=false" >> "$GITHUB_OUTPUT"
+  echo "No forbidden patterns configured"
+  exit 0
+fi
 
 # PRの変更ファイル一覧を取得
 # 方針: セキュリティ必須処理の失敗 → exit 1（禁止パターンチェックのバイパス防止）

--- a/.github/scripts/auto-fix/check-loop-count.sh
+++ b/.github/scripts/auto-fix/check-loop-count.sh
@@ -13,9 +13,9 @@ source "$(dirname "$0")/_common.sh"
 require_env PR_NUMBER GH_REPO GITHUB_OUTPUT
 
 # auto-fix ループのマーカーコメント数をカウント
-# copilot-auto-fix.yml が /check-pr 実行前に投稿する「auto-fix: レビュー指摘への自動対応」コメントを対象
+# copilot-auto-fix.yml が自動修正開始前に投稿する「copilot-auto-fix: Copilot レビュー指摘への自動対応」コメントを対象
 if ! LOOP_COUNT=$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
-  --paginate --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("auto-fix: レビュー指摘への自動対応")))] | length' 2>&1); then
+  --paginate --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("copilot-auto-fix: Copilot レビュー指摘への自動対応")))] | length' 2>&1); then
   echo "::warning::Failed to get loop count: $LOOP_COUNT. Defaulting to 0."
   LOOP_COUNT=0
 fi

--- a/.github/scripts/post-merge/update-review-issue.sh
+++ b/.github/scripts/post-merge/update-review-issue.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../auto-fix/_common.sh"
 
-require_env PR_NUMBER
+require_env PR_NUMBER GH_TOKEN GH_REPO
 validate_pr_number "$PR_NUMBER"
 # PR_TITLE は情報提供目的のため、空でもフォールバックして記録を続行
 PR_TITLE="${PR_TITLE:-(タイトル取得失敗)}"

--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -260,7 +260,7 @@ jobs:
 
           gh_comment "$PR_NUMBER" "## copilot-auto-fix: Copilot レビュー指摘への自動対応
 
-          Copilot のレビュー指摘を検出しました。\`/check-pr\` で自動修正を開始します。
+          Copilot のレビュー指摘を検出しました。claude-code-action で自動修正を開始します。
 
           [Actions ログ](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         env:


### PR DESCRIPTION
## Summary

PR #6 の Copilot レビュー指摘4件を修正。

- **check-forbidden.sh**: `FORBIDDEN_PATTERNS` を `require_env` から除去。workflow input でオプション（default: ''）のため、空の場合は「禁止パターンなし」として即終了するように変更
- **update-review-issue.sh**: `require_env` に `GH_TOKEN` `GH_REPO` を追加（ヘッダーの必須宣言と一致させる）
- **copilot-auto-fix.yml**: PR コメント文言を `/check-pr` → `claude-code-action` に修正（実際の動作と一致させる）
- **check-loop-count.sh**: マーカー文字列を `"copilot-auto-fix: Copilot レビュー指摘への自動対応"` に修正（実際のコメント見出しと一致させる）
- **.gitattributes**: `*.sh` を LF 改行固定に設定

## Test plan

- [ ] shellcheck 通過確認済み（ローカル）
- [ ] 各スクリプトの修正が実際のワークフロー動作に影響しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>