### PR TITLE
test: add temporary caller workflow for late-review-scanner E2E

### DIFF
--- a/.github/workflows/test-late-review-scanner.yml
+++ b/.github/workflows/test-late-review-scanner.yml
@@ -1,0 +1,17 @@
+# Temporary caller for E2E testing — DELETE AFTER TEST
+name: "Test: Late Review Scanner"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  scan:
+    uses: becky3/shared-workflows/.github/workflows/late-review-scanner.yml@main
+    with:
+      scan_hours: 168
+    secrets: inherit


### PR DESCRIPTION
## Summary
- E2Eテスト用の一時的なcaller workflowを追加
- テスト完了後に削除予定

## Test plan
- [ ] PRマージ後、workflow_dispatch で手動トリガー
- [ ] テスト完了後にワークフローファイルを削除