### PR TITLE
fix(late-review-scanner): 不要なSlack通知機能を削除

### DIFF
--- a/.github/workflows/late-review-scanner.yml
+++ b/.github/workflows/late-review-scanner.yml
@@ -28,9 +28,6 @@ on:
         required: false
         type: number
         default: 24
-    secrets:
-      SLACK_WEBHOOK_URL:
-        required: false
 
 permissions:
   contents: read
@@ -55,19 +52,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           SCAN_HOURS: ${{ inputs.scan_hours }}
-
-      # Slack通知（失敗時のみ）
-      - name: Slack notification
-        if: failure()
-        continue-on-error: true
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow
-          mention: here
-          if_mention: failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 concurrency:
   group: late-review-scanner-${{ github.repository }}


### PR DESCRIPTION
## Summary
- `late-review-scanner.yml` から Slack 通知関連を全て削除
  - `secrets.SLACK_WEBHOOK_URL` 定義
  - Slack 通知ステップ（`8398a7/action-slack`）
- reusable workflow の `if` 条件で `secrets` を直接参照できないパースエラーの根本原因も解消

## Test plan
- [ ] `workflow_dispatch` でパースエラーが発生しないことを確認（E2Eテストで検証予定）