### PR TITLE
chore: copilot-auto-fix / post-merge から不要なSlack通知機能を削除

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -9,7 +9,7 @@
 #
 # 呼び出し側の要件:
 #   - permissions: contents: write, pull-requests: write, issues: write, checks: read, actions: read, id-token: write
-#   - secrets: CLAUDE_CODE_OAUTH_TOKEN, REPO_OWNER_PAT, (SLACK_WEBHOOK_URL)
+#   - secrets: CLAUDE_CODE_OAUTH_TOKEN, REPO_OWNER_PAT
 #   - トリガーイベント: pull_request[opened], workflow_dispatch
 #   - プロンプトテンプレート: .github/prompts/auto-fix-check-pr.md（caller リポに配置）
 #
@@ -64,8 +64,6 @@ on:
         required: true
       REPO_OWNER_PAT:
         required: true
-      SLACK_WEBHOOK_URL:
-        required: false
 
 permissions:
   contents: write
@@ -486,18 +484,6 @@ jobs:
           ACTIONS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMON_SCRIPT_PATH: ${{ github.workspace }}/.shared/.github/scripts/auto-fix/_common.sh
 
-      # Slack通知（失敗時のみ）
-      - name: Slack notification
-        if: failure()
-        continue-on-error: true
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow
-          mention: here
-          if_mention: failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 concurrency:
   group: copilot-auto-fix-pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -9,7 +9,7 @@
 #
 # 呼び出し側の要件:
 #   - permissions: contents: read, pull-requests: write, issues: write, id-token: write
-#   - secrets: (SLACK_WEBHOOK_URL)
+#   - secrets: なし（GITHUB_TOKEN で動作）
 #   - トリガーイベント: pull_request[closed]
 #
 # 処理内容:
@@ -22,9 +22,6 @@ name: Post Merge
 
 on:
   workflow_call:
-    secrets:
-      SLACK_WEBHOOK_URL:
-        required: false
 
 permissions:
   contents: read
@@ -57,18 +54,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
 
-      # Slack通知（失敗時のみ）
-      - name: Slack notification
-        if: failure()
-        continue-on-error: true
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow
-          mention: here
-          if_mention: failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 concurrency:
   group: post-merge-pr-${{ github.event.pull_request.number }}

--- a/examples/caller-workflows/copilot-auto-fix.yml
+++ b/examples/caller-workflows/copilot-auto-fix.yml
@@ -6,7 +6,6 @@
 # Required secrets (set in the caller repository):
 #   - CLAUDE_CODE_OAUTH_TOKEN
 #   - REPO_OWNER_PAT
-#   - SLACK_WEBHOOK_URL (optional)
 #
 # Required variables (optional, set in the caller repository):
 #   - COPILOT_REVIEW_TIMEOUT (default: 600 seconds)

--- a/examples/caller-workflows/post-merge.yml
+++ b/examples/caller-workflows/post-merge.yml
@@ -3,8 +3,7 @@
 # This file should be placed in the caller repository as:
 #   .github/workflows/post-merge.yml
 #
-# Required secrets (set in the caller repository):
-#   - SLACK_WEBHOOK_URL (optional)
+# No secrets required (runs with GITHUB_TOKEN).
 
 name: Post Merge
 


### PR DESCRIPTION
## Summary
- `copilot-auto-fix.yml` / `post-merge.yml` から SLACK_WEBHOOK_URL secret 定義と Slack 通知ステップを削除
- caller example のコメントからも SLACK_WEBHOOK_URL の記載を削除
- 仕様書には Slack 通知の記載なし（変更不要）

Closes #17

## Test plan
- [ ] copilot-auto-fix / post-merge のワークフロー定義が正常にパースされることを確認