### PR TITLE
fix(claude): auto_progress_prompt を env 経由で注入

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -113,9 +113,10 @@ jobs:
           bot_id: ${{ inputs.bot_id }}
           claude_args: |
             --model ${{ inputs.model }} --max-turns ${{ inputs.max_turns }} --dangerously-skip-permissions
-            ${{ inputs.auto_progress_prompt != '' && format('--append-system-prompt {0}', toJSON(inputs.auto_progress_prompt)) || '' }}
           show_full_output: true
           label_trigger: "auto-implement"
+        env:
+          APPEND_SYSTEM_PROMPT: ${{ inputs.auto_progress_prompt }}
 
       # auto:pipeline ラベルを付与（検索・フィルタ用。ワークフロー制御には使用しない）
       # ワークフロー制御は auto/ ブランチプレフィックスで判定（branch_prefix パラメータ）


### PR DESCRIPTION
## Summary

- `claude_args` の `--append-system-prompt` は claude-code-action の SDK モードで `systemPrompt` に反映されない問題を修正
- `APPEND_SYSTEM_PROMPT` 環境変数を直接セットする方式に変更
- まず `claude-auto-implement` ジョブのみ適用して検証

## Test plan

- [ ] rag-knowledge Issue #8 で `auto-implement` ラベルを再付与して動作確認
- [ ] Claude がプロンプト到達確認テストに反応するか検証

Generated with [Claude Code](https://claude.ai/code)