### PR TITLE
fix(claude): auto_progress_prompt を prompt input で注入

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -113,6 +113,8 @@ jobs:
           bot_id: ${{ inputs.bot_id }}
           claude_args: |
             --model ${{ inputs.model }} --max-turns ${{ inputs.max_turns }} --dangerously-skip-permissions
+          prompt: ${{ inputs.auto_progress_prompt }}
+          track_progress: true
           show_full_output: true
           label_trigger: "auto-implement"
         env:


### PR DESCRIPTION
## Summary

- `APPEND_SYSTEM_PROMPT` では Claude が指示に従わないため、`prompt` input で注入する方式に変更
- `track_progress: true` で tag mode を維持しつつ `<custom_instructions>` として user prompt 内に追加

## Test plan

- [ ] rag-knowledge Issue #8 で検証

Generated with [Claude Code](https://claude.ai/code)