### PR TITLE
fix(claude): 両ジョブの auto_progress_prompt を prompt input 方式に統一

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ on:
         type: string
         default: '209825114'
       auto_progress_prompt:
-        description: 'System prompt text appended via --append-system-prompt (empty to skip)'
+        description: 'Custom instructions injected via prompt input as <custom_instructions> (empty to skip)'
         required: false
         type: string
         default: ''
@@ -78,7 +78,8 @@ jobs:
           bot_id: ${{ inputs.bot_id }}
           claude_args: |
             --model ${{ inputs.model }} --max-turns ${{ inputs.max_turns }} --dangerously-skip-permissions
-            ${{ inputs.auto_progress_prompt != '' && format('--append-system-prompt {0}', toJSON(inputs.auto_progress_prompt)) || '' }}
+          prompt: ${{ inputs.auto_progress_prompt }}
+          track_progress: true
           show_full_output: true
 
   # auto-implement ラベルによる自動実装トリガー
@@ -117,8 +118,6 @@ jobs:
           track_progress: true
           show_full_output: true
           label_trigger: "auto-implement"
-        env:
-          APPEND_SYSTEM_PROMPT: ${{ inputs.auto_progress_prompt }}
 
       # auto:pipeline ラベルを付与（検索・フィルタ用。ワークフロー制御には使用しない）
       # ワークフロー制御は auto/ ブランチプレフィックスで判定（branch_prefix パラメータ）

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -164,7 +164,7 @@ caller が渡すリポジトリ固有の設定:
 
 - **禁止パターン**: 自動マージをブロックするファイルパターン（caller の `forbidden_patterns` 入力）
 - **プロンプトテンプレート**: レビュー指摘対応プロンプト（caller リポの `.github/prompts/` に配置）
-- **GA 環境ルール**: 自動実装時のシステムプロンプト（caller の `auto_progress_prompt` 入力）
+- **GA 環境ルール**: 自動実装時のカスタム指示（caller の `auto_progress_prompt` 入力。`prompt` input 経由で `<custom_instructions>` として注入）
 
 ### レビュー方式
 

--- a/docs/specs/claude-code-actions.md
+++ b/docs/specs/claude-code-actions.md
@@ -92,7 +92,7 @@ Caller から Reusable Workflow に渡す入力パラメータ:
 | `max_turns` | No | 最大ターン数 |
 | `bot_name` | No | Bot 表示名 |
 | `bot_id` | No | Bot ID |
-| `auto_progress_prompt` | No | GA 環境用の追加システムプロンプト（空文字列で省略） |
+| `auto_progress_prompt` | No | GA 環境用のカスタム指示。`prompt` input 経由で `<custom_instructions>` として注入（空文字列で省略） |
 
 ### シークレット
 


### PR DESCRIPTION
## Summary

- 両ジョブ（claude / claude-auto-implement）で `--append-system-prompt` / `APPEND_SYSTEM_PROMPT` を廃止
- `prompt` input + `track_progress: true` に統一し、`<custom_instructions>` として user prompt 内に注入
- 仕様書2件（auto-progress.md, claude-code-actions.md）の記述を更新

## 背景

- `--append-system-prompt`（claude_args 経由）は claude-code-action の SDK モードで systemPrompt に反映されない
- `APPEND_SYSTEM_PROMPT` 環境変数は systemPrompt.append に入るが、tag mode の user prompt に負けて Claude が従わない
- `prompt` input は tag mode の user prompt 内に `<custom_instructions>` として注入されるため確実に従う

## Test plan

- [x] rag-knowledge Issue #8 で prompt input 方式の動作確認済み（PR #15 作成成功）

Generated with [Claude Code](https://claude.ai/code)