### PR TITLE
fix: 事後レビュー指摘対応（#27）

### DIFF
--- a/.github/scripts/auto-fix/merge-check.sh
+++ b/.github/scripts/auto-fix/merge-check.sh
@@ -26,6 +26,13 @@ require_env PR_NUMBER GITHUB_OUTPUT
 MERGE_READY=true
 REASONS=""
 
+# ラベル一覧を事前取得（条件2・条件5で共用）
+LABELS_FETCHED=true
+if ! LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>&1); then
+  LABELS_FETCHED=false
+  echo "::warning::Failed to retrieve labels (API error): $LABELS"
+fi
+
 # 条件1: PR が OPEN 状態（マージ済み・クローズ済みの PR はスキップ）
 if ! PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>&1); then
   MERGE_READY=false
@@ -41,7 +48,12 @@ else
 fi
 
 # 条件2: レビュー指摘ゼロ（既に has_issues=false で確認済み）
-echo "✅ Condition 2: No review issues"
+# auto:review-skipped ラベルがある場合はレビュー自体が行われていないためスキップ表示
+if [ "$LABELS_FETCHED" = "true" ] && echo "$LABELS" | grep -q "^auto:review-skipped$"; then
+  echo "⏭️ Condition 2: Review skipped (timeout) — covered by late-review-scanner"
+else
+  echo "✅ Condition 2: No review issues"
+fi
 
 # 条件3: CI全チェック通過（GitHub API の statusCheckRollup を使用）
 # EXCLUDE_CHECK が設定されている場合、そのチェック名を除外する
@@ -122,10 +134,9 @@ else
 fi
 
 # 条件5: auto:failed ラベルなし（方針: 一時的API障害 → 安全側に倒してマージ拒否）
-if ! LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>&1); then
+if [ "$LABELS_FETCHED" != "true" ]; then
   MERGE_READY=false
   REASONS="${REASONS}\n- ❌ GitHub API error: Cannot verify labels"
-  echo "::warning::Failed to retrieve labels (API error): $LABELS"
   echo "❌ Condition 5: API error (not label issue)"
 elif echo "$LABELS" | grep -q "^auto:failed$"; then
   MERGE_READY=false

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -164,7 +164,7 @@ caller が渡すリポジトリ固有の設定:
 
 - **禁止パターン**: 自動マージをブロックするファイルパターン（caller の `forbidden_patterns` 入力）
 - **プロンプトテンプレート**: レビュー指摘対応プロンプト（caller リポの `.github/prompts/` に配置）
-- **GA 環境ルール**: 自動実装時のカスタム指示。以下の2つの方式で注入でき、併用も可能:
+- **GA 環境ルール**: auto-progress 関連ジョブで共通利用する GA 環境向けカスタム指示。以下の2つの方式で注入でき、併用も可能:
   - **ファイル配置方式（推奨）**: caller リポの `.claude/CLAUDE-auto-progress.md` に配置。Claude Code がプロジェクト指示として自動読み込みする
   - **input 方式**: caller の `auto_progress_prompt` 入力で渡す。`prompt` input 経由で `<custom_instructions>` として注入
 
@@ -201,12 +201,12 @@ caller が `forbidden_patterns` 入力で指定したファイルパターンに
 
 ### 第4層: concurrency グループ
 
-ワークフローごとに concurrency グループで同時実行を制御する。進行中のジョブはキャンセルしない。
+特定ジョブごとに job-level concurrency グループで同時実行を制御する。進行中のジョブはキャンセルしない。
 
-| ワークフロー | グループキー | 並列実行 |
+| ジョブ | concurrency グループキー | 並列実行 |
 |---|---|---|
-| auto-implement | Issue 番号 | 異なる Issue 間で可能 |
-| copilot-auto-fix | PR 番号 | 異なる PR 間で可能 |
+| claude-auto-implement ジョブ（`.github/workflows/claude.yml`） | `claude-auto-implement-${{ github.event.issue.number }}` | 異なる Issue 間で可能 |
+| copilot-auto-fix ジョブ | `copilot-auto-fix-pr-${{ github.event.pull_request.number }}` | 異なる PR 間で可能 |
 
 ### 第5層: マージ前6条件チェック
 

--- a/docs/specs/copilot-auto-fix.md
+++ b/docs/specs/copilot-auto-fix.md
@@ -126,11 +126,13 @@ unresolved threads は GraphQL API で PR の `reviewThreads` から `isResolved
 以下の 6 条件を全て満たす場合にマージを実行する:
 
 1. PR が OPEN 状態
-2. unresolved threads == 0
+2. unresolved threads == 0（`auto:review-skipped` ラベルがある場合はスキップ）
 3. ステータスチェック通過（外部 CI 未設定時は自動 PASS、自ワークフローは除外）
 4. コンフリクトなし
 5. `auto:failed` ラベルなし
 6. 禁止パターンなし
+
+条件2について: Copilot レビューがタイムアウトで `auto:review-skipped` ラベルが付与されている場合、unresolved threads のチェックはスキップされる（レビュー自体が行われていないため）。この場合、事後レビュー（late-review-scanner）でカバーする。
 
 条件3の判定では、CheckRun（`status` / `conclusion`）と StatusContext（`state`）を区別して評価する。実行中（IN_PROGRESS / PENDING）のチェックは CI 完了待機ステップで解消済みのため、マージ判定時点では完了済みチェックのみが対象となる。
 

--- a/examples/caller-workflows/post-merge.yml
+++ b/examples/caller-workflows/post-merge.yml
@@ -20,4 +20,3 @@ on:
 jobs:
   post-merge:
     uses: becky3/shared-workflows/.github/workflows/post-merge.yml@main
-    secrets: inherit


### PR DESCRIPTION
## 概要

Issue #27 の事後レビュー指摘に対応。修正可能なファイル（ドキュメント・スクリプト・サンプル）を修正し、ワークフローファイル（`.github/workflows/`）の指摘は別 Issue として記録。

## 変更内容

### 修正済み

- **PR#26 指摘**: `examples/caller-workflows/post-merge.yml` から不要な `secrets: inherit` を削除（ヘッダーコメントとの不整合を解消）
- **PR#30 指摘**: `docs/specs/auto-progress.md` のGA環境ルール説明を「自動実装時」→「auto-progress 関連ジョブ共通」に修正
- **PR#37 指摘**: `docs/specs/auto-progress.md` の concurrency セクションを「ワークフロー」→「ジョブ」レベル表記に修正し、実際のグループキーを明記
- **PR#40 指摘（仕様書）**: `docs/specs/copilot-auto-fix.md` のマージ条件2に `auto:review-skipped` 時のスキップを明記
- **PR#40 指摘（スクリプト）**: `.github/scripts/auto-fix/merge-check.sh` でラベル事前取得によるAPIコール削減、review-skipped 時の Condition 2 出力を改善
- **PR#40 指摘（ラベル）**: `auto:review-skipped` は `scripts/setup-labels.sh` に既に存在（対応不要）

### 未対応（ワークフローファイル変更不可のため別 Issue が必要）

- **PR#23 指摘**: `.github/workflows/late-review-scanner-caller.yml` のコメント修正・`uses` をローカル参照に変更
- **PR#29 指摘**: `.github/workflows/claude.yml` の prompt input を空でない場合のみ渡すように修正

Closes #27

Generated with [Claude Code](https://claude.ai/code)