### PR TITLE
fix: 事後レビュー指摘の対応 (#27)

### DIFF
--- a/.github/scripts/auto-fix/merge-check.sh
+++ b/.github/scripts/auto-fix/merge-check.sh
@@ -9,6 +9,7 @@
 #   EXCLUDE_CHECK   — （任意）CI チェック除外名。自ワークフローの自己参照防止用
 #   FORBIDDEN_DETECTED — （任意）禁止パターン検出結果。"true" の場合マージ拒否
 #   FORBIDDEN_FILES  — （任意）禁止パターン該当ファイル一覧（multiline）。REASONS に含める
+#   REVIEW_SKIPPED   — （任意）"true" の場合、レビュースキップ（タイムアウト）。条件2の表示を変更
 #
 # 出力（$GITHUB_OUTPUT）:
 #   merge_ready     — "true" / "false"
@@ -41,7 +42,12 @@ else
 fi
 
 # 条件2: レビュー指摘ゼロ（既に has_issues=false で確認済み）
-echo "✅ Condition 2: No review issues"
+# REVIEW_SKIPPED=true の場合はレビュー未実施のためチェックをスキップ
+if [ "${REVIEW_SKIPPED:-}" = "true" ]; then
+  echo "⏭️ Condition 2: Review skipped (timeout) — unresolved threads check not applicable"
+else
+  echo "✅ Condition 2: No review issues"
+fi
 
 # 条件3: CI全チェック通過（GitHub API の statusCheckRollup を使用）
 # EXCLUDE_CHECK が設定されている場合、そのチェック名を除外する

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -78,6 +78,8 @@ jobs:
           bot_id: ${{ inputs.bot_id }}
           claude_args: |
             --model ${{ inputs.model }} --max-turns ${{ inputs.max_turns }} --dangerously-skip-permissions
+          # auto_progress_prompt が空の場合は空文字列が渡される
+          # claude-code-action は空文字列の prompt を「追加指示なし」として扱う（デフォルト動作を上書きしない）
           prompt: ${{ inputs.auto_progress_prompt }}
           track_progress: true
           show_full_output: true

--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -469,6 +469,7 @@ jobs:
           EXCLUDE_CHECK: ${{ inputs.exclude_check }}
           FORBIDDEN_DETECTED: ${{ steps.forbidden-check.outputs.forbidden }}
           FORBIDDEN_FILES: ${{ steps.forbidden-check.outputs.forbidden_files }}
+          REVIEW_SKIPPED: ${{ steps.copilot-timeout.outputs.review_skipped }}
 
       - name: Merge or dry-run
         if: steps.merge-check.outputs.merge_ready == 'true'

--- a/.github/workflows/late-review-scanner-caller.yml
+++ b/.github/workflows/late-review-scanner-caller.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   scan:
-    uses: becky3/shared-workflows/.github/workflows/late-review-scanner.yml@main
+    uses: ./.github/workflows/late-review-scanner.yml
     with:
       scan_hours: 24
     secrets: inherit

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -164,7 +164,7 @@ caller が渡すリポジトリ固有の設定:
 
 - **禁止パターン**: 自動マージをブロックするファイルパターン（caller の `forbidden_patterns` 入力）
 - **プロンプトテンプレート**: レビュー指摘対応プロンプト（caller リポの `.github/prompts/` に配置）
-- **GA 環境ルール**: 自動実装時のカスタム指示。以下の2つの方式で注入でき、併用も可能:
+- **GA 環境ルール**: auto-progress 関連ジョブ（`claude` / `claude-auto-implement`）で共通利用する GA 環境向けカスタム指示。以下の2つの方式で注入でき、併用も可能:
   - **ファイル配置方式（推奨）**: caller リポの `.claude/CLAUDE-auto-progress.md` に配置。Claude Code がプロジェクト指示として自動読み込みする
   - **input 方式**: caller の `auto_progress_prompt` 入力で渡す。`prompt` input 経由で `<custom_instructions>` として注入
 
@@ -201,12 +201,12 @@ caller が `forbidden_patterns` 入力で指定したファイルパターンに
 
 ### 第4層: concurrency グループ
 
-ワークフローごとに concurrency グループで同時実行を制御する。進行中のジョブはキャンセルしない。
+ジョブレベルの concurrency グループで同時実行を制御する。進行中のジョブはキャンセルしない。
 
-| ワークフロー | グループキー | 並列実行 |
+| ジョブ | グループキー | 並列実行 |
 |---|---|---|
-| auto-implement | Issue 番号 | 異なる Issue 間で可能 |
-| copilot-auto-fix | PR 番号 | 異なる PR 間で可能 |
+| `claude-auto-implement` ジョブ（`claude.yml`） | `claude-auto-implement-${{ github.event.issue.number }}` | 異なる Issue 間で可能 |
+| `copilot-auto-fix` ジョブ（`copilot-auto-fix.yml`） | `copilot-auto-fix-pr-${{ github.event.pull_request.number }}` | 異なる PR 間で可能 |
 
 ### 第5層: マージ前6条件チェック
 

--- a/docs/specs/copilot-auto-fix.md
+++ b/docs/specs/copilot-auto-fix.md
@@ -126,7 +126,7 @@ unresolved threads は GraphQL API で PR の `reviewThreads` から `isResolved
 以下の 6 条件を全て満たす場合にマージを実行する:
 
 1. PR が OPEN 状態
-2. unresolved threads == 0
+2. unresolved threads == 0（`auto:review-skipped` 時はスキップ: レビュー未実施のため unresolved threads チェック不要）
 3. ステータスチェック通過（外部 CI 未設定時は自動 PASS、自ワークフローは除外）
 4. コンフリクトなし
 5. `auto:failed` ラベルなし

--- a/examples/caller-workflows/post-merge.yml
+++ b/examples/caller-workflows/post-merge.yml
@@ -20,4 +20,3 @@ on:
 jobs:
   post-merge:
     uses: becky3/shared-workflows/.github/workflows/post-merge.yml@main
-    secrets: inherit


### PR DESCRIPTION
## 概要

Issue #27 で報告された事後レビュー指摘（全9件・6PR分）に対応。

### 変更内容

- **PR #26**: `examples/caller-workflows/post-merge.yml` から不要な `secrets: inherit` を削除（コメントの「No secrets required」と一致させる）
- **PR #23**: `.github/workflows/late-review-scanner-caller.yml` の `uses:` をローカル参照 `./.github/workflows/late-review-scanner.yml` に変更（`claude-caller.yml` と同じパターンに統一）
- **PR #29**: `claude.yml` の `prompt` パラメータに空文字列時の動作をコメントで明記
- **PR #30**: `docs/specs/auto-progress.md` の `auto_progress_prompt` 説明を「自動実装時」から「両ジョブ共通の GA 環境向けカスタム指示」に修正
- **PR #37**: `docs/specs/auto-progress.md` の concurrency テーブルをジョブレベルの記述に更新し、実際のグループキーと一致させる
- **PR #40**: 
  - `docs/specs/copilot-auto-fix.md` のマージ判定条件2に `auto:review-skipped` 時のスキップを明記
  - `.github/scripts/auto-fix/merge-check.sh` に `REVIEW_SKIPPED` 環境変数を追加し、レビュースキップ時は条件2を「skipped」と表示
  - `.github/workflows/copilot-auto-fix.yml` から merge-check に `REVIEW_SKIPPED` を受け渡し
  - `scripts/setup-labels.sh` は既に `auto:review-skipped` ラベルが定義済みのため変更不要

Closes #27

Generated with [Claude Code](https://claude.ai/code)