### PR TITLE
fix(copilot-auto-fix): プロンプトテンプレートを配置

### DIFF
--- a/.github/prompts/auto-fix-check-pr.md
+++ b/.github/prompts/auto-fix-check-pr.md
@@ -45,6 +45,7 @@ gh api graphql -f query="
       }
     }
   }
+}
 " --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .comments.nodes[0] | {author: .author.login, path, line, body}'
 ```
 

--- a/examples/prompts/auto-fix-check-pr.md
+++ b/examples/prompts/auto-fix-check-pr.md
@@ -45,6 +45,7 @@ gh api graphql -f query="
       }
     }
   }
+}
 " --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .comments.nodes[0] | {author: .author.login, path, line, body}'
 ```
 


### PR DESCRIPTION
## Change type

- [x] fix

## Summary

- `.github/prompts/auto-fix-check-pr.md` を配置（`examples/prompts/` からコピー）
- copilot-auto-fix-caller が PR #51 で発火した際、「Load prompt template」ステップで当ファイルが見つからず失敗していた
- caller ワークフロー追加（PR #50）に対応するプロンプトテンプレートの配置漏れ

## Test plan

- [ ] PR #51 に対して copilot-auto-fix を workflow_dispatch で再実行し、Load prompt template が成功することを確認

## Related issues

Closes #42