### PR TITLE
fix: 事後レビュー指摘の対応 (#27)

### DIFF
--- a/.github/scripts/auto-fix/merge-check.sh
+++ b/.github/scripts/auto-fix/merge-check.sh
@@ -7,6 +7,7 @@
 #   GH_TOKEN        — GitHub トークン（env経由で gh CLI が自動参照）
 #   GH_REPO         — 対象リポジトリ（owner/repo）
 #   EXCLUDE_CHECK   — （任意）CI チェック除外名。自ワークフローの自己参照防止用
+#   REVIEW_SKIPPED  — （任意）"true" の場合、レビュースキップ（タイムアウト）。条件2を免除
 #   FORBIDDEN_DETECTED — （任意）禁止パターン検出結果。"true" の場合マージ拒否
 #   FORBIDDEN_FILES  — （任意）禁止パターン該当ファイル一覧（multiline）。REASONS に含める
 #
@@ -41,7 +42,12 @@ else
 fi
 
 # 条件2: レビュー指摘ゼロ（既に has_issues=false で確認済み）
-echo "✅ Condition 2: No review issues"
+# REVIEW_SKIPPED=true の場合はレビュー自体が行われていないため免除
+if [ "${REVIEW_SKIPPED:-}" = "true" ]; then
+  echo "⏭️ Condition 2: Review skipped (timeout) — waived"
+else
+  echo "✅ Condition 2: No review issues"
+fi
 
 # 条件3: CI全チェック通過（GitHub API の statusCheckRollup を使用）
 # EXCLUDE_CHECK が設定されている場合、そのチェック名を除外する

--- a/.github/scripts/auto-fix/merge-check.sh
+++ b/.github/scripts/auto-fix/merge-check.sh
@@ -41,8 +41,7 @@ else
   echo "✅ Condition 1: PR is OPEN"
 fi
 
-# 条件2: レビュー指摘ゼロ（既に has_issues=false で確認済み）
-# REVIEW_SKIPPED=true の場合はレビュー自体が行われていないため免除
+# 条件2: レビュー指摘ゼロ（上流で review 結果を判定済み。REVIEW_SKIPPED=true の場合は免除）
 if [ "${REVIEW_SKIPPED:-}" = "true" ]; then
   echo "⏭️ Condition 2: Review skipped (timeout) — waived"
 else

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -164,7 +164,7 @@ caller が渡すリポジトリ固有の設定:
 
 - **禁止パターン**: 自動マージをブロックするファイルパターン（caller の `forbidden_patterns` 入力）
 - **プロンプトテンプレート**: レビュー指摘対応プロンプト（caller リポの `.github/prompts/` に配置）
-- **GA 環境ルール**: 自動実装時のカスタム指示。以下の2つの方式で注入でき、併用も可能:
+- **GA 環境ルール**: auto-progress 関連ジョブで共通利用する GA 環境向けカスタム指示。以下の2つの方式で注入でき、併用も可能:
   - **ファイル配置方式（推奨）**: caller リポの `.claude/CLAUDE-auto-progress.md` に配置。Claude Code がプロジェクト指示として自動読み込みする
   - **input 方式**: caller の `auto_progress_prompt` 入力で渡す。`prompt` input 経由で `<custom_instructions>` として注入
 
@@ -201,12 +201,12 @@ caller が `forbidden_patterns` 入力で指定したファイルパターンに
 
 ### 第4層: concurrency グループ
 
-ワークフローごとに concurrency グループで同時実行を制御する。進行中のジョブはキャンセルしない。
+特定ジョブごとに job-level concurrency グループで同時実行を制御する。進行中のジョブはキャンセルしない。
 
-| ワークフロー | グループキー | 並列実行 |
+| ジョブ | concurrency グループキー | 並列実行 |
 |---|---|---|
-| auto-implement | Issue 番号 | 異なる Issue 間で可能 |
-| copilot-auto-fix | PR 番号 | 異なる PR 間で可能 |
+| claude-auto-implement ジョブ (`.github/workflows/claude.yml`) | `claude-auto-implement-${{ github.event.issue.number }}` | 異なる Issue 間で可能 |
+| copilot-auto-fix ジョブ | PR 番号 | 異なる PR 間で可能 |
 
 ### 第5層: マージ前6条件チェック
 

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -206,7 +206,7 @@ caller が `forbidden_patterns` 入力で指定したファイルパターンに
 | ジョブ | concurrency グループキー | 並列実行 |
 |---|---|---|
 | claude-auto-implement ジョブ (`.github/workflows/claude.yml`) | `claude-auto-implement-${{ github.event.issue.number }}` | 異なる Issue 間で可能 |
-| copilot-auto-fix ジョブ | PR 番号 | 異なる PR 間で可能 |
+| copilot-auto-fix ジョブ (`.github/workflows/copilot-auto-fix.yml`) | `copilot-auto-fix-pr-${{ github.event.pull_request.number \|\| github.event.inputs.pr_number }}` | 異なる PR 間で可能 |
 
 ### 第5層: マージ前6条件チェック
 

--- a/docs/specs/copilot-auto-fix.md
+++ b/docs/specs/copilot-auto-fix.md
@@ -126,11 +126,13 @@ unresolved threads は GraphQL API で PR の `reviewThreads` から `isResolved
 以下の 6 条件を全て満たす場合にマージを実行する:
 
 1. PR が OPEN 状態
-2. unresolved threads == 0
+2. unresolved threads == 0（`auto:review-skipped` 時はスキップ）
 3. ステータスチェック通過（外部 CI 未設定時は自動 PASS、自ワークフローは除外）
 4. コンフリクトなし
 5. `auto:failed` ラベルなし
 6. 禁止パターンなし
+
+条件2は、Copilot レビューがタイムアウトにより `auto:review-skipped` が付与された場合、レビュー自体が行われていないため条件を免除する（事後レビュー late-review-scanner でカバー）。
 
 条件3の判定では、CheckRun（`status` / `conclusion`）と StatusContext（`state`）を区別して評価する。実行中（IN_PROGRESS / PENDING）のチェックは CI 完了待機ステップで解消済みのため、マージ判定時点では完了済みチェックのみが対象となる。
 

--- a/examples/caller-workflows/post-merge.yml
+++ b/examples/caller-workflows/post-merge.yml
@@ -20,4 +20,3 @@ on:
 jobs:
   post-merge:
     uses: becky3/shared-workflows/.github/workflows/post-merge.yml@main
-    secrets: inherit


### PR DESCRIPTION
## 概要

Issue #27 の事後レビュー指摘（PR #26, #29, #30, #37, #40 のレビューコメント）に対応。

## 変更内容

### 直接修正（本PR）
- `examples/caller-workflows/post-merge.yml`: 不要な `secrets: inherit` を削除（PR #26 指摘）
- `docs/specs/auto-progress.md`: `auto_progress_prompt` の適用範囲を正確な表現に修正（PR #30 指摘）
- `docs/specs/auto-progress.md`: concurrency セクションを job-level の正確な表現に修正（PR #37 指摘）
- `docs/specs/copilot-auto-fix.md`: マージ判定条件2が `auto:review-skipped` 時に免除される旨を明記（PR #40 指摘）
- `.github/scripts/auto-fix/merge-check.sh`: `REVIEW_SKIPPED` 環境変数に対応し条件2のログ出力を正確に（PR #40 指摘）

### 別 Issue に起票（ワークフローファイル変更のため）
- #53: `late-review-scanner-caller.yml` のコメント修正 + ローカル参照化（PR #23 指摘）
- #54: `claude.yml` の `prompt` input を非空時のみ渡す（PR #29 指摘）
- #55: `copilot-auto-fix.yml` に `REVIEW_SKIPPED` 環境変数追加（PR #40 指摘）

### 対応不要
- PR #40 の `setup-labels.sh` への `auto:review-skipped` 追加 → 既に追加済み

Closes #27

Generated with [Claude Code](https://claude.ai/code)