### PR TITLE
ci: claude.yml に dotfiles の共通 .claude/ マージステップを追加 (#57)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -78,7 +78,13 @@ jobs:
           path: dotfiles-tmp
           sparse-checkout: .claude
       - name: Merge dotfiles .claude/
-        run: cp -rn dotfiles-tmp/.claude/* .claude/ 2>/dev/null || true
+        run: |
+          if [ -d "dotfiles-tmp/.claude" ]; then
+            mkdir -p .claude
+            cp -a -n dotfiles-tmp/.claude/. .claude/
+          else
+            echo "::warning::.claude directory not found in dotfiles; skipping merge."
+          fi
 
       - uses: anthropics/claude-code-action@5994afaaa7f44611addc97a696a135acff5fd218 # v1.0.46
         with:
@@ -132,7 +138,13 @@ jobs:
           path: dotfiles-tmp
           sparse-checkout: .claude
       - name: Merge dotfiles .claude/
-        run: cp -rn dotfiles-tmp/.claude/* .claude/ 2>/dev/null || true
+        run: |
+          if [ -d "dotfiles-tmp/.claude" ]; then
+            mkdir -p .claude
+            cp -a -n dotfiles-tmp/.claude/. .claude/
+          else
+            echo "::warning::.claude directory not found in dotfiles; skipping merge."
+          fi
 
       - uses: anthropics/claude-code-action@5994afaaa7f44611addc97a696a135acff5fd218 # v1.0.46
         with:


### PR DESCRIPTION
## Change type

- [x] ci

## Summary

- claude.yml の両ジョブ（`claude`, `claude-auto-implement`）に dotfiles checkout + `.claude/` マージステップを追加
- GA環境で dotfiles の共通ルール・エージェント・スキルが参照可能になる
- `cp -rn`（no-clobber）でプロジェクト固有のファイルは上書きしない

## Test plan

- [x] YAML 構文確認
- [ ] GA環境で共通ルールが参照できることを確認

## Related issues

Closes #57