### PR TITLE
docs: dotfiles → agent-commons 参照更新 (#124)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,21 +69,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # dotfiles の共通 .claude/ をマージ（agents, skills, rules 等）
-      - name: Checkout dotfiles
+      # agent-commons の共通 .claude/ をマージ（agents, skills, rules 等）
+      - name: Checkout agent-commons
         uses: actions/checkout@v4
         with:
-          repository: becky3/dotfiles
+          repository: becky3/agent-commons
           token: ${{ secrets.REPO_OWNER_PAT }}
-          path: dotfiles-tmp
+          path: agent-commons-tmp
           sparse-checkout: .claude
-      - name: Merge dotfiles .claude/
+      - name: Merge agent-commons .claude/
         run: |
-          if [ -d "dotfiles-tmp/.claude" ]; then
+          if [ -d "agent-commons-tmp/.claude" ]; then
             mkdir -p .claude
-            cp -a -n dotfiles-tmp/.claude/. .claude/
+            cp -a -n agent-commons-tmp/.claude/. .claude/
           else
-            echo "::warning::.claude directory not found in dotfiles; skipping merge."
+            echo "::warning::.claude directory not found in agent-commons; skipping merge."
           fi
 
       - uses: anthropics/claude-code-action@5994afaaa7f44611addc97a696a135acff5fd218 # v1.0.46
@@ -129,21 +129,21 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # dotfiles の共通 .claude/ をマージ（agents, skills, rules 等）
-      - name: Checkout dotfiles
+      # agent-commons の共通 .claude/ をマージ（agents, skills, rules 等）
+      - name: Checkout agent-commons
         uses: actions/checkout@v4
         with:
-          repository: becky3/dotfiles
+          repository: becky3/agent-commons
           token: ${{ secrets.REPO_OWNER_PAT }}
-          path: dotfiles-tmp
+          path: agent-commons-tmp
           sparse-checkout: .claude
-      - name: Merge dotfiles .claude/
+      - name: Merge agent-commons .claude/
         run: |
-          if [ -d "dotfiles-tmp/.claude" ]; then
+          if [ -d "agent-commons-tmp/.claude" ]; then
             mkdir -p .claude
-            cp -a -n dotfiles-tmp/.claude/. .claude/
+            cp -a -n agent-commons-tmp/.claude/. .claude/
           else
-            echo "::warning::.claude directory not found in dotfiles; skipping merge."
+            echo "::warning::.claude directory not found in agent-commons; skipping merge."
           fi
 
       - uses: anthropics/claude-code-action@5994afaaa7f44611addc97a696a135acff5fd218 # v1.0.46

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ bash scripts/setup.sh owner/repo your_github_username --force
 | Secret | 必須 | 説明 |
 |--------|:----:|------|
 | `CLAUDE_CODE_OAUTH_TOKEN` | Yes | Claude Code Action の認証トークン |
-| `REPO_OWNER_PAT` | Yes | ワークフロー連鎖・PR 作成・dotfiles 読み取り用の Personal Access Token |
+| `REPO_OWNER_PAT` | Yes | ワークフロー連鎖・PR 作成・agent-commons 読み取り用の Personal Access Token |
 
 設定場所: リポジトリの Settings > Secrets and variables > Actions > **New repository secret**
 
@@ -126,14 +126,14 @@ claude setup-token
 
 #### REPO_OWNER_PAT の取得
 
-GitHub Personal Access Token。ワークフロー連鎖（GITHUB_TOKEN で作成した PR は他のワークフローをトリガーしない制約の回避）、PR 作成、および dotfiles リポジトリからの共通設定取得に使用する。
+GitHub Personal Access Token。ワークフロー連鎖（GITHUB_TOKEN で作成した PR は他のワークフローをトリガーしない制約の回避）、PR 作成、および agent-commons リポジトリからの共通設定取得に使用する。
 
 **Fine-grained token（推奨）:**
 
 1. GitHub > Settings > Developer settings > [Personal access tokens > Fine-grained tokens](https://github.com/settings/tokens?type=beta)
 2. **Generate new token** をクリック
 3. Token name: 任意（例: `shared-workflows-pat`）
-4. Repository access: **All repositories** または対象リポジトリ + `becky3/dotfiles` を個別選択
+4. Repository access: **All repositories** または対象リポジトリ + `becky3/agent-commons` を個別選択
 5. Permissions:
    - **Contents**: Read and write
    - **Issues**: Read and write

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -160,9 +160,9 @@ stateDiagram-v2
 | `post-merge.yml` | `pull_request[closed]` | マージ後の全 PR レビュー記録 |
 | `late-review-scanner.yml` | `schedule` + `workflow_dispatch` | マージ済み PR の事後レビュー指摘を検出・集約 |
 
-### dotfiles マージ
+### agent-commons マージ
 
-`claude.yml` の各ジョブ（メンション応答・自動実装）の実行前に、dotfiles リポジトリから共通の `.claude/` 設定（エージェント・スキル・ルール等）を取得し、プロジェクトの `.claude/` にマージする。プロジェクト固有のファイルが既に存在する場合は上書きしない（no-clobber）。
+`claude.yml` の各ジョブ（メンション応答・自動実装）の実行前に、agent-commons リポジトリから共通の `.claude/` 設定（エージェント・スキル・ルール等）を取得し、プロジェクトの `.claude/` にマージする。プロジェクト固有のファイルが既に存在する場合は上書きしない（no-clobber）。
 
 これにより、ローカル環境と同じエージェント・スキル・ルールが GA 環境でも利用可能になる。
 

--- a/docs/specs/claude-code-actions.md
+++ b/docs/specs/claude-code-actions.md
@@ -48,7 +48,7 @@ OAuth 認証を使用する。
 flowchart TD
     A[イベント発火] --> B{セキュリティチェック}
     B -->|NG| C[スキップ]
-    B -->|OK| D[dotfiles マージ<br/>共通 .claude/ 設定取得]
+    B -->|OK| D[agent-commons マージ<br/>共通 .claude/ 設定取得]
     D --> E[Claude Code 起動]
     E --> F[コンテキスト取得<br/>Issue/PR 情報]
     F --> G[タスク実行]
@@ -56,7 +56,7 @@ flowchart TD
 ```
 
 1. **セキュリティチェック**: ユーザー制限・メンション有無を検証し、条件を満たさない場合はスキップ
-2. **dotfiles マージ**: dotfiles リポジトリから共通の `.claude/` 設定（エージェント・スキル・ルール等）を取得し、プロジェクトの `.claude/` にマージする。プロジェクト固有のファイルは上書きしない（no-clobber）
+2. **agent-commons マージ**: agent-commons リポジトリから共通の `.claude/` 設定（エージェント・スキル・ルール等）を取得し、プロジェクトの `.claude/` にマージする。プロジェクト固有のファイルは上書きしない（no-clobber）
 3. **Claude Code 起動**: OAuth トークンで認証し、ターン制限付きで起動
 4. **コンテキスト取得**: 対象の Issue / PR の情報を取得
 5. **タスク実行**: メンション内容に基づきコードレビュー・実装・質問応答を実行
@@ -103,7 +103,7 @@ Caller から Reusable Workflow に渡す入力パラメータ:
 | シークレット | 概要 |
 |---|---|
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code Action の OAuth トークン |
-| `REPO_OWNER_PAT` | ワークフロー連鎖・PR 作成用の個人アクセストークン。dotfiles リポジトリへの読み取りアクセスも必要 |
+| `REPO_OWNER_PAT` | ワークフロー連鎖・PR 作成用の個人アクセストークン。agent-commons リポジトリへの読み取りアクセスも必要 |
 
 ## 関連ドキュメント
 


### PR DESCRIPTION
## Change type

- [x] ci — CI/CD improvements
- [x] docs — Documentation only

## Summary

- `claude.yml` の repository 参照を `becky3/dotfiles` → `becky3/agent-commons` に更新（2ジョブ分）
- checkout パス・ステップ名・コメント・warning メッセージを一括更新
- `README.md` の REPO_OWNER_PAT 説明を更新（3箇所）
- `auto-progress.md` のセクション名と説明を更新
- `claude-code-actions.md` の mermaid 図・処理フロー・シークレット説明を更新

## Test plan

- [x] リポジトリ全体の「dotfiles」検索で残留 0 件を確認
- [x] doc-reviewer によるレビュー実施済み（指摘 0 件）
- [x] code-reviewer によるレビュー実施済み（指摘 0 件）
- [ ] CI でワークフロー構文エラーがないことを確認

## Related issues

Closes becky3/agent-commons#124

🤖 Generated with [Claude Code](https://claude.com/claude-code)