### PR TITLE
fix(claude): 配置先で意味不明化するヘッダーコメントを修正 (#88)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bash.exe.stackdump
 .claude/settings.local.json
 .pr-creation-authorized
 .claude/scheduled_tasks.lock
+aidlc-docs/
+aidlc-archive/

--- a/examples/caller-workflows/claude.yml
+++ b/examples/caller-workflows/claude.yml
@@ -1,7 +1,7 @@
 # Claude Code — Caller Workflow Example
 #
 # このファイルを呼び出し側リポジトリの .github/workflows/claude.yml に配置する。
-# <YOUR_USERNAME> を GitHub ユーザー名に置き換えること。
+# 許可ユーザーは下記 allowed_user に GitHub ユーザー名を指定する（setup.sh 経由なら自動置換）。
 #
 # 前提:
 #   - Secrets: CLAUDE_CODE_OAUTH_TOKEN, REPO_OWNER_PAT


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `examples/caller-workflows/claude.yml` のヘッダーコメント L4 から `<YOUR_USERNAME>` プレースホルダ表現を除去
- setup.sh の文字列置換でコメントが「becky3 を GitHub ユーザー名に置き換えること」のように自己言及で意味不明化していた問題を解消（Issue 推奨の対策案 A）
- 置換シミュレーション (`${content//<YOUR_USERNAME>/becky3}`) で、L4 が置換非対象・L32 の `allowed_user` のみが置換されることを確認
- `.gitignore` に `aidlc-docs/` / `aidlc-archive/` を追加（/start-work・/auto-finalize 作業領域の追跡除外）

## Test plan

- [x] 品質チェック（test-runner エージェント）通過済み
- [x] setup.sh 置換ロジックのローカルシミュレーションでヘッダーコメントが意味を保つことを確認
- [x] 既存セットアップ済みリポ（article-writer・py-common-lib）への追従は実害なしのため不要と判断（コメントの自己言及は混乱要因だが動作影響なし）

## Related issues

Closes #88