### PR TITLE
fix(claude,copilot-auto-fix): 無効な allowed_tools 除去と Opus デフォルトの最新追従化 (#90)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ on:
         description: 'Claude model to use'
         required: false
         type: string
-        default: 'claude-opus-4-6'
+        default: 'opus'
       max_turns:
         description: 'Maximum conversation turns'
         required: false
@@ -156,9 +156,6 @@ jobs:
           bot_id: ${{ inputs.bot_id }}
           claude_args: |
             --model ${{ inputs.model }} --max-turns ${{ inputs.max_turns }} --dangerously-skip-permissions
-          # gh コマンドを許可: PR作成・Issue操作に必要
-          # デフォルトの allowed_tools には git コマンドのみで gh が含まれない
-          allowed_tools: "Bash(gh:*)"
           prompt: ${{ inputs.auto_progress_prompt }}
           track_progress: true
           show_full_output: true

--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -38,7 +38,7 @@ on:
         description: 'Claude model to use for auto-fix'
         required: false
         type: string
-        default: 'claude-opus-4-6'
+        default: 'opus'
       max_turns:
         description: 'Maximum conversation turns for Claude'
         required: false

--- a/examples/caller-workflows/claude.yml
+++ b/examples/caller-workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
     uses: becky3/shared-workflows/.github/workflows/claude.yml@main
     with:
       allowed_user: "<YOUR_USERNAME>"
-      # model: "claude-opus-4-6"       # default
+      # model: "opus"                  # default
       # max_turns: 100                  # default
       auto_progress_prompt: "GA環境専用ルールが .claude/CLAUDE-auto-progress.md にあります。このファイルを必ず読んでから作業を開始してください。ファイルが見つからない・読めない場合は、その旨をIssue/PRにコメントして作業を中断してください。"
     secrets:


### PR DESCRIPTION
## Change type

- [x] fix

## Summary

- `claude.yml`: `model` 入力デフォルトを `claude-opus-4-6`（バージョン固定）→ `opus`（最新 Opus 自動追従エイリアス）に変更
- `claude.yml`: claude-code-action v1.0.46 で silently 無視される dead config の `allowed_tools: "Bash(gh:*)"` とその説明コメント2行を削除（`--dangerously-skip-permissions` が全ツール許可を担うため挙動退行なし）
- `copilot-auto-fix.yml`: `model` 入力デフォルトを `opus` に変更
- `examples/caller-workflows/claude.yml`: コメント例を `# model: "opus"` に追従更新

## Test plan

- [x] actionlint で全ワークフロー検証（EXIT=0、構文エラーなし）
- [x] `claude-opus-4-6` / `allowed_tools` のリポジトリ内残存ゼロを git grep で確認
- [x] code-reviewer レビュー: 指摘なし

## Related issues

Closes #90