### PR TITLE
feat(copilot-auto-fix): Copilot 自動レビュー設定（ruleset）連動スキップ (#94)

### DIFF
--- a/.github/scripts/auto-fix/check-copilot-review-status.sh
+++ b/.github/scripts/auto-fix/check-copilot-review-status.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# check-copilot-review-status -- Copilot 自動レビュー有効判定
+#
+# リポジトリの ruleset に有効な copilot_code_review ルールがあるかを確認し、
+# 標準出力へ "on"（自動レビュー有効）/ "off"（無効）を出力する。
+#
+# 判定の SSoT は GitHub の実設定（ruleset）そのもの。
+# active な ruleset のいずれかに type=copilot_code_review のルールがあれば "on"、
+# なければ "off"。
+#
+# エラー・判定不能時は "on" を出力する（安全側デフォルト。
+# 誤って off に倒すと自動レビュー有効なのにレビュー待ちをスキップする恐れがあるため）。
+#
+# 入力（環境変数）:
+#   GH_TOKEN  -- GitHub トークン。未設定時は gh api が認証エラーで失敗し "on" フォールバックになる
+#   GH_REPO   -- 対象リポジトリ owner/repo（必須）
+#
+# 出力:
+#   標準出力: "on" または "off"（それ以外は出力しない）
+#   診断メッセージ: 標準エラー出力
+#
+# 注意:
+#   --paginate を使用するため ruleset が多いリポジトリでは複数の API 呼び出しが発生する。
+#   通常の運用規模（~数十件）では問題にならない。
+#
+# 終了コード:
+#   0 — 常に 0（エラー時は "on" を出力して続行）
+
+set -uo pipefail
+
+NWO="${GH_REPO:-}"
+
+if [ -z "$NWO" ]; then
+  echo "::warning::GH_REPO is not set. Defaulting to on." >&2
+  echo "on"
+  exit 0
+fi
+
+# active な ruleset の ID 一覧を取得
+# includes_parents=true で組織レベルから継承される ruleset も対象に含める
+# （リポジトリレベルに ruleset が無く組織側で copilot_code_review を配布する運用に対応）
+# --paginate で全ページを走査する（ruleset が 1 ページ上限を超えても見落とさない）
+if ! RULESETS=$(gh api --paginate "repos/$NWO/rulesets?includes_parents=true" \
+    --jq '.[] | select(.enforcement=="active") | .id' 2>/dev/null); then
+  echo "::warning::Failed to fetch rulesets for $NWO. Defaulting to on." >&2
+  echo "on"
+  exit 0
+fi
+
+if [ -z "$RULESETS" ]; then
+  echo "No active rulesets found. Copilot auto-review disabled." >&2
+  echo "off"
+  exit 0
+fi
+
+while IFS= read -r RID; do
+  [ -z "$RID" ] && continue
+  # ruleset 詳細を取得。取得失敗（権限不足等）は安全側に倒して on を返す
+  # （黙って off に倒すと、自動レビュー有効なのにレビュー待ちをスキップする恐れがあるため）
+  if HIT=$(gh api "repos/$NWO/rulesets/$RID" \
+      --jq '.rules[]? | select(.type=="copilot_code_review") | .type' 2>/dev/null); then
+    if [ -n "$HIT" ]; then
+      echo "copilot_code_review rule found in ruleset $RID. Copilot auto-review enabled." >&2
+      echo "on"
+      exit 0
+    fi
+  else
+    echo "::warning::Failed to fetch ruleset $RID details. Defaulting to on." >&2
+    echo "on"
+    exit 0
+  fi
+done <<< "$RULESETS"
+
+echo "No copilot_code_review rule found in any active ruleset. Copilot auto-review disabled." >&2
+echo "off"
+exit 0

--- a/.github/scripts/auto-fix/wait-for-copilot.sh
+++ b/.github/scripts/auto-fix/wait-for-copilot.sh
@@ -12,9 +12,11 @@
 #
 # 出力:
 #   copilot_reviewed=true|false（$GITHUB_OUTPUT 経由）
+#   copilot_review_enabled=true|false（$GITHUB_OUTPUT 経由）
+#     false: ruleset に copilot_code_review ルールが無く自動レビューが無効
 #
 # 終了コード:
-#   0 — タイムアウト or 正常検知（copilot_reviewed で呼び出し元が判断）
+#   0 — タイムアウト / 正常検知 / 自動レビュー無効（copilot_reviewed で呼び出し元が判断）
 #   1 — 回復不能エラー（権限/認証エラー）
 # API エラー:
 #   認証/権限エラー（401/403/forbidden/resource not accessible）→ exit 1（即停止）
@@ -29,6 +31,21 @@ source "$SCRIPT_DIR/_common.sh"
 
 require_env PR_NUMBER GH_TOKEN GH_REPO GITHUB_OUTPUT
 validate_pr_number "$PR_NUMBER" "PR_NUMBER"
+
+# --- Copilot 自動レビュー有効判定 ---
+# ruleset に copilot_code_review ルールが無ければ待機を即スキップ
+REVIEW_STATUS=$(bash "$SCRIPT_DIR/check-copilot-review-status.sh" 2>/dev/null) || REVIEW_STATUS="on"
+# stdout が on/off 以外（空文字含む）の場合は安全側にフォールバック
+if [ "$REVIEW_STATUS" != "off" ]; then
+  REVIEW_STATUS="on"
+fi
+if [ "$REVIEW_STATUS" = "off" ]; then
+  echo "Copilot auto-review is disabled for $GH_REPO (no copilot_code_review ruleset rule). Skipping review wait."
+  output "copilot_reviewed" "false"
+  output "copilot_review_enabled" "false"
+  exit 0
+fi
+output "copilot_review_enabled" "true"
 
 TIMEOUT="${COPILOT_REVIEW_TIMEOUT:-900}"
 POLL_INTERVAL=30

--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -203,23 +203,54 @@ jobs:
           COPILOT_REVIEW_TIMEOUT: ${{ vars.COPILOT_REVIEW_TIMEOUT }}
 
       - name: Handle Copilot review timeout
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'false'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'false' && steps.copilot-wait.outputs.copilot_review_enabled == 'true'
         id: copilot-timeout
         continue-on-error: true
         run: |
           # マージパスへの続行を最優先で出力（API 障害でステップ失敗しても merge-path で拾えるよう continue-on-error と併用）
           echo "review_skipped=true" >> "$GITHUB_OUTPUT"
 
-          source "$GITHUB_WORKSPACE/.shared/.github/scripts/auto-fix/_common.sh"
           PR_NUMBER="${{ steps.pr-info.outputs.number }}"
-
-          gh_safe gh issue edit "$PR_NUMBER" --add-label "auto:review-skipped"
-          gh_comment "$PR_NUMBER" "## copilot-auto-fix: Copilot レビュースキップ
+          COMMON="$GITHUB_WORKSPACE/.shared/.github/scripts/auto-fix/_common.sh"
+          # shellcheck disable=SC1090
+          if source "$COMMON"; then
+            gh_safe gh issue edit "$PR_NUMBER" --add-label "auto:review-skipped"
+            gh_comment "$PR_NUMBER" "## copilot-auto-fix: Copilot レビュースキップ
 
           Copilot のレビューが制限時間内に検知されませんでした。
           レビューをスキップしてマージ判定に進みます（事後レビュー late-review-scanner でカバー）。
 
           [Actions ログ](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          else
+            echo "::warning::Failed to source _common.sh. Label and comment steps skipped."
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+
+      - name: Handle Copilot review disabled
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_review_enabled == 'false'
+        id: copilot-review-disabled
+        continue-on-error: true
+        run: |
+          # マージパスへの続行を最優先で出力（API 障害でステップ失敗しても merge-path で拾えるよう continue-on-error と併用）
+          echo "review_skipped=true" >> "$GITHUB_OUTPUT"
+
+          PR_NUMBER="${{ steps.pr-info.outputs.number }}"
+          COMMON="$GITHUB_WORKSPACE/.shared/.github/scripts/auto-fix/_common.sh"
+          # shellcheck disable=SC1090
+          if source "$COMMON"; then
+            gh_safe gh issue edit "$PR_NUMBER" --add-label "auto:review-skipped"
+            gh_comment "$PR_NUMBER" "## copilot-auto-fix: Copilot レビュースキップ（自動レビュー無効）
+
+          このリポジトリの ruleset に \`copilot_code_review\` ルールが設定されていないため、Copilot 自動レビューをスキップしてマージ判定に進みます。
+
+          Copilot 自動レビューを有効にするには、リポジトリの Settings > Rules > Rulesets で \`copilot_code_review\` ルールを追加してください。
+
+          [Actions ログ](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          else
+            echo "::warning::Failed to source _common.sh. Label and comment steps skipped."
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -383,7 +414,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
       # --- マージ判定 ---
-      # 条件: (Copilot検知済み AND (指摘なし OR 修正完了)) OR レビュースキップ
+      # 条件: (Copilot検知済み AND (指摘なし OR 修正完了)) OR レビュースキップ（タイムアウト OR 自動レビュー無効）
       # 禁止パターンはマージ直前にチェックし、merge-check.sh 内で条件6として判定
       # 品質チェック（pytest/ruff/mypy/markdownlint）はエージェント内テストで担保済み（外部CIワークフロー不使用）
 
@@ -394,14 +425,23 @@ jobs:
         run: |
           set -euo pipefail
           COPILOT_REVIEWED="${{ steps.copilot-wait.outputs.copilot_reviewed }}"
-          REVIEW_SKIPPED="${{ steps.copilot-timeout.outputs.review_skipped }}"
+          REVIEW_SKIPPED_TIMEOUT="${{ steps.copilot-timeout.outputs.review_skipped }}"
+          REVIEW_SKIPPED_DISABLED="${{ steps.copilot-review-disabled.outputs.review_skipped }}"
           HAS_ISSUES="${{ steps.review-result.outputs.has_issues }}"
           RECOUNT_HAS_ISSUES="${{ steps.recount.outputs.has_issues }}"
 
+          # ステップが skipped の場合 outputs は空文字列になるため、明示的に false 初期化してから true チェックする
+          REVIEW_SKIPPED="false"
+          if [ "$REVIEW_SKIPPED_TIMEOUT" = "true" ] || [ "$REVIEW_SKIPPED_DISABLED" = "true" ]; then
+            REVIEW_SKIPPED="true"
+          fi
+
           if [ "$REVIEW_SKIPPED" = "true" ]; then
             echo "eligible=true" >> "$GITHUB_OUTPUT"
-            echo "Merge path: review skipped (timeout)"
+            echo "Merge path: review skipped (timeout or disabled)"
           elif [ "$COPILOT_REVIEWED" = "true" ]; then
+            # RECOUNT_HAS_ISSUES は HAS_ISSUES=true 時のみステップが実行されるため、
+            # ステップ skipped 時は空文字列になる。空文字列は "true" でないため eligible=true に倒れる
             if [ "$HAS_ISSUES" != "true" ] || [ "$RECOUNT_HAS_ISSUES" != "true" ]; then
               echo "eligible=true" >> "$GITHUB_OUTPUT"
               echo "Merge path: review completed, issues resolved"


### PR DESCRIPTION
## Change type

- [x] feat — New feature ★

## Summary

- `check-copilot-review-status.sh` を新規作成: GitHub ruleset の `copilot_code_review` ルール有無を検査し `on`/`off` を stdout に出力（エラー・判定不能時は安全側 `on` にフォールバック）
- `wait-for-copilot.sh` 修正: ポーリング開始前に上記スクリプトを呼び出し、`off`（自動レビュー無効）なら即座に `copilot_reviewed=false` + `copilot_review_enabled=false` を出力してスキップ
- `copilot-auto-fix.yml` 修正: `Handle Copilot review disabled` ステップを追加（`auto:review-skipped` ラベル付与 + "自動レビュー無効" PR コメント）、タイムアウトステップの条件をポジティブマッチに変更、`merge-path` を両スキップ経路に対応

## Test plan

- [x] shellcheck: `check-copilot-review-status.sh` / `wait-for-copilot.sh` ともにクリーン
- [x] actionlint: `copilot-auto-fix.yml` クリーン（`# shellcheck disable=SC1090` を追加済み）
- [x] code-reviewer による指摘をすべて対応済み（Critical 2件・Warning 4件）

## Related issues

Closes #94